### PR TITLE
Update to `Substrate` type

### DIFF
--- a/slm.toml
+++ b/slm.toml
@@ -1,5 +1,5 @@
 name = "jlc-pcb"
-version = "0.2.0"
+version = "0.3.0"
 [dependencies]
 maybe-utils = { git = "StanzaOrg/maybe-utils", version = "0.1.6"}
 

--- a/slm.toml
+++ b/slm.toml
@@ -1,4 +1,5 @@
 name = "jlc-pcb"
 version = "0.2.0"
 [dependencies]
+maybe-utils = { git = "StanzaOrg/maybe-utils", version = "0.1.6"}
 

--- a/src/stackups/JLC04161H-1080.stanza
+++ b/src/stackups/JLC04161H-1080.stanza
@@ -1,0 +1,123 @@
+#use-added-syntax(jitx)
+defpackage jlc-pcb/stackups/JLC04161H-1080:
+  import core
+  import jitx
+
+  import jsl
+  import maybe-utils
+
+  import jlc-pcb/stackups/materials
+  import jlc-pcb/stackups/vias
+
+; Non-dispersive Medium Assumption
+; Average the permittivity with air as an approximation.
+val med-velocity = phase-velocity((Er-1080 + 1.0) / 2.0)
+
+
+public val stackup-gen = make-layer-stack("JLC04161H-1080", outers) where:
+  val cu-1oz = Copper(0.035)
+  val cu-halfoz = Copper(0.0152)
+
+  val core = FR4(1.265, name = "core")
+  val prepreg-1080x1 = FR4(0.0764, name = "1080x1")
+
+  val outers = [
+    [cu-1oz, prepreg-1080x1],
+    [cu-halfoz, core]
+  ]
+
+public defn se-50 (neckdown:Maybe<NeckDown> = None()) -> RoutingStructure:
+  val se-50-ustrip = RoutingStructureLayerConstraints(
+    trace-width = 0.1176,
+    clearance = 0.3,
+    velocity = med-velocity
+    insertion-loss = Dk-prepreg
+    neck-down = value-or-else(neckdown, {false})
+  )
+  pcb-routing-structure se-50-int:
+    name = "50 Single-Ended - CPWG - JLC04161H-7628"
+    layer-constraints(Top) = se-50-ustrip
+    layer-constraints(Bottom) = se-50-ustrip
+  se-50-int
+
+
+doc: \<DOC>
+Default Uncoupled Region for the diff-100
+<DOC>
+public pcb-routing-structure uncoupled-diff-100-def:
+  val df-100-ustrip = RoutingStructureLayerConstraints(
+    trace-width = 0.1041,
+    clearance = 0.25,
+    velocity = med-velocity
+    insertion-loss = Dk-prepreg
+  )
+  layer-constraints(Top) = df-100-ustrip
+  layer-constraints(Bottom) = df-100-ustrip
+
+
+public pcb-differential-routing-structure diff-100 (
+  uncoupled:Maybe<RoutingStructure> = None()
+  neckdown:Maybe<DifferentialNeckDown> = None()
+  ):
+  name = "100 Ohm Differential Pair - CPWG - JLC04161H-7628"
+
+  make-uncoupled-region(uncoupled-diff-100-def, uncoupled)
+
+  val df-100 = DiffRoutingStructureLayerConstraints(
+    trace-width = 0.1041
+    pair-spacing = 0.25
+    clearance = 0.3
+    velocity = med-velocity
+    insertion-loss = Dk-prepreg
+    neck-down = value-or-else(neckdown, {false})
+  )
+  ; Assumes Reference on Top + 1
+  layer-constraints(Top) = df-100
+  layer-constraints(Bottom) = df-100
+
+public pcb-routing-structure uncoupled-diff-90-def:
+  val df-90-ustrip = RoutingStructureLayerConstraints(
+    trace-width = 0.13180,
+    clearance = 0.25,
+    velocity = med-velocity
+    insertion-loss = Dk-prepreg
+  )
+  layer-constraints(Top) = df-90-ustrip
+  layer-constraints(Bottom) = df-90-ustrip
+
+
+public pcb-differential-routing-structure diff-90 (
+  uncoupled:Maybe<RoutingStructure> = None()
+  neckdown:Maybe<DifferentialNeckDown> = None()
+  ):
+  name = "90 Ohm Differential Pair - CPWG - JLC04161H-7628"
+
+  make-uncoupled-region(uncoupled-diff-90-def, uncoupled)
+
+  val df-90 = DiffRoutingStructureLayerConstraints(
+    trace-width = 0.1318
+    pair-spacing = 0.25
+    clearance = 0.3
+    velocity = med-velocity
+    insertion-loss = Dk-prepreg
+    neck-down = value-or-else(neckdown, {false})
+  )
+  ; Assumes Reference on Top + 1
+  layer-constraints(Top) = df-90
+  layer-constraints(Bottom) = df-90
+
+
+public defn JLC04161H-1080 (vias:Tuple<Via> = JLC-VIA-DEFAULTS) -> Substrate :
+  Substrate(
+    stackup = stackup-gen,
+    vias = [
+      std-via-preferred, tented-filled-std-via
+    ],
+    single-ended = [
+      50 => se-50,
+    ]
+    differential = [
+      90 => diff-90,
+      100 => diff-100,
+    ]
+  )

--- a/src/stackups/JLC04161H-7628.stanza
+++ b/src/stackups/JLC04161H-7628.stanza
@@ -2,9 +2,16 @@
 defpackage jlc-pcb/stackups/JLC04161H-7628:
   import core
   import jitx
-  import jsl/layerstack
-  import jsl/si/physics
+
+  import jsl
+  import maybe-utils
+
   import jlc-pcb/stackups/materials
+  import jlc-pcb/stackups/vias
+
+; Non-dispersive Medium Assumption
+; Average the permittivity with air as an approximation.
+val med-velocity = phase-velocity((Er-7628 + 1.0) / 2.0)
 
 
 public val stackup-gen = make-layer-stack("JLC04161H-7628", outers) where:
@@ -19,153 +26,97 @@ public val stackup-gen = make-layer-stack("JLC04161H-7628", outers) where:
     [cu-halfoz, core]
   ]
 
-public val stackup = create-pcb-stackup(stackup-gen)
-
-public defn se-50 ( -- neckdown:NeckDown|False = false):
-
-  pcb-routing-structure se-50-int:
-    name = "50 Single-Ended - CPWG - JLC04161H-7628"
-
-    layer-constraints(Top): ; Microstrip
-      ; Assumes Reference on (Top + 1)
-      trace-width = 0.3244
-      clearance = 0.3
-      ; Non-dispersive Medium Assumption
-      ; Average the permittivity with air as an approximation.
-      velocity = phase-velocity((Er-7628 + 1.0) / 2.0)
-      insertion-loss = Dk-prepreg
-      match(neckdown):
-        (_:False): false
-        (given:NeckDown):
-          neck-down = given
-
-    layer-constraints(Bottom): ; Microstrip
-      ; Assumes Reference on (Bottom + 1)
-      trace-width = 0.3244
-      clearance = 0.3
-      ; Non-dispersive Medium Assumption
-      ; Average the permittivity with air as an approximation.
-      velocity = phase-velocity((Er-7628 + 1.0) / 2.0)
-      insertion-loss = Dk-prepreg
-      match(neckdown):
-        (_:False): false
-        (given:NeckDown):
-          neck-down = given
-  se-50-int
+public pcb-routing-structure se-50 (neckdown:Maybe<NeckDown> = None()):
+  name = "50Ω Single-Ended - CPWG - JLC04161H-7628"
+  ; Expects a ground ref plane on Top + 1 (or Bottom + 1)
+  val se-50-ustrip = RoutingStructureLayerConstraints(
+    trace-width = 0.3244,
+    clearance = 0.3,
+    velocity = med-velocity
+    insertion-loss = Dk-prepreg
+    neck-down = value-or-else(neckdown, {false})
+  )
+  layer-constraints(Top) = se-50-ustrip
+  layer-constraints(Bottom) = se-50-ustrip
 
 
 doc: \<DOC>
 Default Uncoupled Region for the diff-100
 <DOC>
 public pcb-routing-structure uncoupled-diff-100-def:
-  layer-constraints(Top): ; Microstrip
-    ; Assumes Reference on (Top + 1)
-    trace-width = 0.1722
-    clearance = 0.15
-    ; Non-dispersive Medium Assumption
-    ; Average the permittivity with air as an approximation.
-    velocity = phase-velocity((Er-7628 + 1.0) / 2.0)
+  val df-100-ustrip = RoutingStructureLayerConstraints(
+    trace-width = 0.1722,
+    clearance = 0.15,
+    velocity = med-velocity
     insertion-loss = Dk-prepreg
-
-  layer-constraints(Bottom): ; Microstrip
-    ; Assumes Reference on (Bottom + 1)
-    trace-width = 0.1722
-    clearance = 0.15
-    ; Non-dispersive Medium Assumption
-    ; Average the permittivity with air as an approximation.
-    velocity = phase-velocity((Er-7628 + 1.0) / 2.0)
-    insertion-loss = Dk-prepreg
+  )
+  layer-constraints(Top) = df-100-ustrip
+  layer-constraints(Bottom) = df-100-ustrip
 
 
 public pcb-differential-routing-structure diff-100 (
-  --
-  uncoupled:RoutingStructure|False = uncoupled-diff-100-def
-  neckdown:DifferentialNeckDown|False = false
+  uncoupled:Maybe<RoutingStructure> = None()
+  neckdown:Maybe<DifferentialNeckDown> = None()
   ):
-  name = "100 Ohm Differential Pair - CPWG - JLC04161H-7628"
+  name = "100Ω Differential Pair - CPWG - JLC04161H-7628"
 
-  match(uncoupled):
-    (_:False): false
-    (given:RoutingStructure):
-      uncoupled-region = given
+  make-uncoupled-region(uncoupled-diff-100-def, uncoupled)
 
-  layer-constraints(Top):
-    ; Assumes Reference on Top + 1
+  val df-100 = DiffRoutingStructureLayerConstraints(
     trace-width = 0.1722
     pair-spacing = 0.15
     clearance = 0.3
-    velocity = phase-velocity((Er-7628 + 1.0) / 2.0)
+    velocity = med-velocity
     insertion-loss = Dk-prepreg
-    match(neckdown):
-      (_:False): false
-      (given:DifferentialNeckDown):
-        neck-down = given
-
-  layer-constraints(Bottom):
-    ; Assumes Reference on Bottom + 1
-    trace-width = 0.1722
-    pair-spacing = 0.15
-    clearance = 0.3
-    velocity = phase-velocity((Er-7628 + 1.0) / 2.0)
-    insertion-loss = Dk-prepreg
-    match(neckdown):
-      (_:False): false
-      (given:DifferentialNeckDown):
-        neck-down = given
-
-
+    neck-down = value-or-else(neckdown, {false})
+  )
+  ; Assumes Reference on Top + 1
+  layer-constraints(Top) = df-100
+  layer-constraints(Bottom) = df-100
 
 public pcb-routing-structure uncoupled-diff-90-def:
-  layer-constraints(Top): ; Microstrip
-    ; Assumes Reference on (Top + 1)
-    trace-width = 0.2332
-    clearance = 0.15
-    ; Non-dispersive Medium Assumption
-    ; Average the permittivity with air as an approximation.
-    velocity = phase-velocity((Er-7628 + 1.0) / 2.0)
+  val df-90-ustrip = RoutingStructureLayerConstraints(
+    trace-width = 0.2332,
+    clearance = 0.15,
+    velocity = med-velocity
     insertion-loss = Dk-prepreg
+  )
+  layer-constraints(Top) = df-90-ustrip
+  layer-constraints(Bottom) = df-90-ustrip
 
-  layer-constraints(Bottom): ; Microstrip
-    ; Assumes Reference on (Bottom + 1)
-    trace-width = 0.2332
-    clearance = 0.15
-    ; Non-dispersive Medium Assumption
-    ; Average the permittivity with air as an approximation.
-    velocity = phase-velocity((Er-7628 + 1.0) / 2.0)
-    insertion-loss = Dk-prepreg
 
 public pcb-differential-routing-structure diff-90 (
-  --
-  uncoupled:RoutingStructure|False = uncoupled-diff-90-def
-  neckdown:DifferentialNeckDown|False = false
+  uncoupled:Maybe<RoutingStructure> = None()
+  neckdown:Maybe<DifferentialNeckDown> = None()
   ):
-  name = "90 Ohm Differential Pair - CPWG - JLC04161H-7628"
+  name = "90Ω Differential Pair - CPWG - JLC04161H-7628"
 
-  match(uncoupled):
-    (_:False): false
-    (given:RoutingStructure):
-      uncoupled-region = given
+  make-uncoupled-region(uncoupled-diff-90-def, uncoupled)
 
-  layer-constraints(Top):
-    ; Assumes Reference on Top + 1
+  val df-90 = DiffRoutingStructureLayerConstraints(
     trace-width = 0.2332
     pair-spacing = 0.15
     clearance = 0.3
-    velocity = phase-velocity((Er-7628 + 1.0) / 2.0)
+    velocity = med-velocity
     insertion-loss = Dk-prepreg
-    match(neckdown):
-      (_:False): false
-      (given:DifferentialNeckDown):
-        neck-down = given
+    neck-down = value-or-else(neckdown, {false})
+  )
+  ; Assumes Reference on Top + 1
+  layer-constraints(Top) = df-90
+  layer-constraints(Bottom) = df-90
 
-  layer-constraints(Bottom):
-    ; Assumes Reference on Bottom + 1
-    trace-width = 0.2332
-    pair-spacing = 0.15
-    clearance = 0.3
-    velocity = phase-velocity((Er-7628 + 1.0) / 2.0)
-    insertion-loss = Dk-prepreg
-    match(neckdown):
-      (_:False): false
-      (given:DifferentialNeckDown):
-        neck-down = given
+
+public defn JLC04161H-7628 (vias:Tuple<Via> = JLC-VIA-DEFAULTS) -> Substrate :
+  Substrate(
+    stackup = stackup-gen,
+    vias = [
+      std-via-preferred, tented-filled-std-via
+    ],
+    single-ended = [
+      50 => se-50,
+    ]
+    differential = [
+      90 => diff-90,
+      100 => diff-100,
+    ]
+  )

--- a/src/stackups/JLC06161H-7628.stanza
+++ b/src/stackups/JLC06161H-7628.stanza
@@ -2,13 +2,15 @@
 defpackage jlc-pcb/stackups/JLC06161H-7628:
   import core
   import jitx
+  import jitx/commands
 
-  import jsl/layerstack
-  import jsl/si/physics
+  import maybe-utils
+  import jsl
 
+  import jlc-pcb/stackups/vias
   import jlc-pcb/stackups/materials
 
-public val stackup = make-layer-stack("JLC06161H-7628", outers) where:
+public val stackup-gen = make-layer-stack("JLC06161H-7628", outers) where:
   val cu-1oz = Copper(0.035)
   val cu-halfoz = Copper(0.0152)
 
@@ -26,95 +28,99 @@ public val stackup = make-layer-stack("JLC06161H-7628", outers) where:
 ; Routing Structures
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+val ext-velocity = phase-velocity((Er-7628 + 1.0) / 2.0)
+val int-velocity = phase-velocity((Er-7628 + Er-core) / 2.0)
 
-public pcb-routing-structure se-50 (nd:Maybe<NeckDown> = None()):
-  name = "50 Single-Ended - CPWG - JLC06161H-7628"
+public pcb-routing-structure se-50 (neckdown:Maybe<NeckDown> = None()):
+  name = "50Ω Single-Ended - CPWG - JLC06161H-7628"
 
-  layer-constraints(Top): ; Microstrip
-    ; Assumes Reference on (Top + 1)
-    trace-width = 0.3421
-    clearance = 0.5
-    ; Non-dispersive Medium Assumption
-    velocity = phase-velocity(Er-7628)
-    match(nd):
-      (_:None): false
-      (given:One<NeckDown>):
-        neck-down = one(given)
+  ; This expects a ground ref plane on Top + 1
+  val ext-se-50-ustrip = RoutingStructureLayerConstraints(
+    trace-width = 0.3421,
+    clearance = 0.5,
+    velocity = ext-velocity
+    insertion-loss = Dk-prepreg
+    neck-down = value-or-else(neckdown, {false})
+  )
 
-  layer-constraints(Bottom): ; Microstrip
-    ; Assumes Reference on (Bottom + 1)
-    trace-width = 0.3421
-    clearance = 0.5
-    ; Non-dispersive Medium Assumption
-    velocity = phase-velocity(Er-7628)
-    match(nd):
-      (_:None): false
-      (given:One<NeckDown>):
-        neck-down = one(given)
+  ; This expects a ground ref plane on Top and Top + 2 (or Bottom and Bottom + 2)
+  val int-se-50-stripline = RoutingStructureLayerConstraints(
+    trace-width = 0.2230,
+    clearance = 0.3,
+    velocity = int-velocity
+    insertion-loss = Dk-prepreg
+    neck-down = value-or-else(neckdown, {false})
+  )
 
-  layer-constraints(Top+1): ; stripline
-    ; Assumes Top and Top + 2 are ground reference planes
-    trace-width = 0.2230
-    clearance = 0.3
-    ; Non-dispersive Medium Assumption
-    ; This is an approximation between the materials
-    ;  above and below this layer will be diffferent
-    ;  and have different permittivities.
-    velocity = phase-velocity((Er-7628 + Er-core) / 2.0)
+  layer-constraints(Top) = ext-se-50-ustrip
+  layer-constraints(Bottom) = ext-se-50-ustrip
+  layer-constraints(Top + 1) = int-se-50-stripline
+  layer-constraints(Bottom + 1) = int-se-50-stripline
 
-  layer-constraints(Bottom+1): ; stripline
-    ; Assumes Bottom and Bottom + 2 are ground reference planes
-    trace-width = 0.2230
-    clearance = 0.3
-    ; Non-dispersive Medium Assumption
-    ; This is an approximation between the materials
-    ;  above and below this layer will be diffferent
-    ;  and have different permittivities.
-    velocity = phase-velocity((Er-7628 + Er-core) / 2.0)
+
+public pcb-routing-structure uncoupled-diff-100-def:
+  val df-100-ustrip = RoutingStructureLayerConstraints(
+    trace-width = 0.1722,
+    clearance = 0.15,
+    velocity = ext-velocity
+    insertion-loss = Dk-prepreg
+  )
+  val df-100-stripline = RoutingStructureLayerConstraints(
+    trace-width = 0.1298,
+    clearance = 0.15,
+    velocity = int-velocity
+    insertion-loss = Dk-prepreg
+  )
+
+  layer-constraints(Top) = df-100-ustrip
+  layer-constraints(Bottom) = df-100-ustrip
+
+  layer-constraints(Top + 1) = df-100-stripline
+  layer-constraints(Bottom + 1) = df-100-stripline
 
 public pcb-differential-routing-structure diff-100 (
   uncoupled:Maybe<RoutingStructure> = None()
   neckdown:Maybe<DifferentialNeckDown> = None()
   ):
-  name = "100 Ohm Differential Pair - CPWG - JLC06161H-7628"
+  name = "100Ω Differential Pair - CPWG - JLC06161H-7628"
 
-  match(uncoupled):
-    (_:None): false
-    (given:One<RoutingStructure>):
-      uncoupled-region = one(given)
+  make-uncoupled-region(uncoupled-diff-100-def, uncoupled)
 
-  layer-constraints(Top):
-    ; Assumes Reference on Top + 1
+  ; This expects a ground ref plane on Top + 1
+  val df-100-ustrip = DiffRoutingStructureLayerConstraints(
     trace-width = 0.1722
     pair-spacing = 0.15
     clearance = 0.3
-    velocity = phase-velocity(Er-7628)
-    match(neckdown):
-      (_:None): false
-      (given:One<DifferentialNeckDown>):
-        neck-down = one(given)
+    velocity = ext-velocity
+    insertion-loss = Dk-prepreg
+    neck-down = value-or-else(neckdown, {false})
+  )
+  layer-constraints(Top) = df-100-ustrip
+  layer-constraints(Bottom) = df-100-ustrip
 
-  layer-constraints(Bottom):
-    ; Assumes Reference on Bottom + 1
-    trace-width = 0.1722
+  ; This expects a ground ref plane on Top and Top + 2 (or Bottom and Bottom + 2)
+  val df-100-stripline = DiffRoutingStructureLayerConstraints(
+    trace-width = 0.1298
     pair-spacing = 0.15
     clearance = 0.3
-    velocity = phase-velocity(Er-7628)
-    match(neckdown):
-      (_:None): false
-      (given:One<DifferentialNeckDown>):
-        neck-down = one(given)
+    velocity = int-velocity
+    insertion-loss = Dk-prepreg
+    neck-down = value-or-else(neckdown, {false})
+  )
 
-  layer-constraints(Top+1):
-    ; Assumes Reference on Top and `Top + 2`
-    trace-width = 0.1298 
-    pair-spacing = 0.15
-    clearance = 0.3
-    velocity = phase-velocity((Er-7628 + Er-core) / 2.0)
+  layer-constraints(Top + 1) = df-100-stripline
+  layer-constraints(Bottom + 1) = df-100-stripline
 
-  layer-constraints(Bottom+1):
-    ; Assumes Reference on Bottom and `Bottom + 2`
-    trace-width = 0.1298 
-    pair-spacing = 0.15
-    clearance = 0.3
-    velocity = phase-velocity((Er-7628 + Er-core) / 2.0)
+public defn JLC06161H-7628 (vias:Tuple<Via> = JLC-VIA-DEFAULTS) -> Substrate :
+  Substrate(
+    stackup = stackup-gen,
+    vias = [
+      std-via-preferred, tented-filled-std-via
+    ],
+    single-ended = [
+      50 => se-50,
+    ]
+    differential = [
+      100 => diff-100,
+    ]
+  )

--- a/src/stackups/vias.stanza
+++ b/src/stackups/vias.stanza
@@ -32,7 +32,7 @@ public pcb-via std-via-preferred:
   via-in-pad = false
 
 doc: \<DOC>
-Multi-layer (6+) via with extra cost + 1. 
+Multi-layer (6+) via with extra cost + 1.
 There are multiple levels of extra cost that
 JLCPCB supports for smaller vias. This is the
 first layer.
@@ -49,7 +49,7 @@ public pcb-via multi-via-cost+1:
   via-in-pad = false
 
 doc: \<DOC>
-Multi-layer (6+) via with extra cost + 1. 
+Multi-layer (6+) via with extra cost + 1.
 There are multiple levels of extra cost that
 JLCPCB supports for smaller vias. This is the
 first layer.
@@ -66,7 +66,7 @@ public pcb-via multi-via-cost+1-preferred:
   via-in-pad = false
 
 doc: \<DOC>
-Multi-layer (6+) via with extra cost + 2. 
+Multi-layer (6+) via with extra cost + 2.
 <DOC>
 public pcb-via multi-via-cost+2:
   name = "Multi-Layer Via Aggressive - Cost + 2"
@@ -78,7 +78,7 @@ public pcb-via multi-via-cost+2:
   via-in-pad = false
 
 doc: \<DOC>
-Multi-layer (6+) via with extra cost + 2. 
+Multi-layer (6+) via with extra cost + 2.
 This via definition uses the preferred +0.15mm
 for the pad diameter which JLC-PCB recommends
 <DOC>
@@ -92,7 +92,7 @@ public pcb-via multi-via-cost+2-preferred:
   via-in-pad = false
 
 doc: \<DOC>
-Multi-layer (6+) via with extra cost + 3. 
+Multi-layer (6+) via with extra cost + 3.
 <DOC>
   public pcb-via multi-via-cost+3:
   name = "Multi-Layer Via Aggressive - Cost + 3"
@@ -104,7 +104,7 @@ Multi-layer (6+) via with extra cost + 3.
   via-in-pad = false
 
 doc: \<DOC>
-Multi-layer (6+) via with extra cost + 3. 
+Multi-layer (6+) via with extra cost + 3.
 This via definition uses the preferred +0.15mm
 for the pad diameter which JLC-PCB recommends
 <DOC>
@@ -135,3 +135,16 @@ public pcb-via tented-filled-std-via:
   tented = true
   filled = true
   via-in-pad = true
+
+doc: \<DOC>
+Minimal Default Via Set for JLC-PCB boards
+
+This contains the standard preferred via and the
+standard tented and filled via as options for all boards.
+
+These vias (as of 10/23/2024) do not have any up charge
+for processing.
+<DOC>
+public val JLC-VIA-DEFAULTS = [
+  std-via-preferred, tented-filled-std-via
+]


### PR DESCRIPTION
This updates the JLC stackups to use the `Substrate` type defined in JSL. 
I've also added an additional stackup from JLC that supports smaller traces and lower loss.